### PR TITLE
Fix tests

### DIFF
--- a/tests/src/bitmap_painter.cpp
+++ b/tests/src/bitmap_painter.cpp
@@ -14,6 +14,7 @@ static void assert_pixel_color(bitmap_painter const& painter, vector2ui const& p
 	if (!pixel_color_matches)
 	{
 		int i = 0;
+		(void)i;
 	}
 
 	ASSERT_TRUE(pixel_color_matches);

--- a/tests/src/obj_import.cpp
+++ b/tests/src/obj_import.cpp
@@ -66,10 +66,10 @@ static void assert_obj_texcoords(mesh const& mesh)
 	ASSERT_NE(texcoords_info, nullptr);
 
 	std::vector<vector2f> const correct_texcoords
-		{ vector2{0.0f, 0.0f},
-		  vector2{1.0f, 0.0f},
-		  vector2{1.0f, 1.0f},
-		  vector2(0.0f, 1.0f) };
+		{ vector2f{0.0f, 0.0f},
+		  vector2f{1.0f, 0.0f},
+		  vector2f{1.0f, 1.0f},
+		  vector2f(0.0f, 1.0f) };
 
 	ASSERT_EQ(texcoords_info->get_data().size(), 4);
 	for (size_t i{0}; i < 4; ++i)


### PR DESCRIPTION
Happy New 2015 Year!

I check that last tests version fail to compile, so I fix theme.

Off-top: do you know that rotation_car_app do not rotate now? It happen after commit dca6ef9944e669300bc7cc96c5735a31cd2f0462 - obj import rewritten + basic shader system
Did this only working moment and it will be fixed in future?

P.S.
By the way, I make some little work in reason 'Proof of concept' and make some SDL_Free (https://github.com/TheVice/lantern/tree/SDL_Free), so now not even via SDL wrapper can be displayed.
Known issue at this variant:
-empty_app not recommended to run at Linux, in my opinion XSendEvent call too often to force redraw;
-do not know but both app's do not draw in Windows 8.1 on VirtualBox, but tests pass;
-do not tested on Mac OS X.