### PR TITLE
[MinGW] fix compiling error

### DIFF
--- a/lantern/include/geometry_stage.h
+++ b/lantern/include/geometry_stage.h
@@ -3,7 +3,7 @@
 
 #include "mesh.h"
 #include "texture.h"
-#include "vector4.h"
+#include "matrix4x4.h"
 
 namespace lantern
 {

--- a/lantern/include/renderer.h
+++ b/lantern/include/renderer.h
@@ -5,6 +5,7 @@
 #include "geometry_stage.h"
 #include "rasterizing_stage.h"
 #include "merging_stage.h"
+#include <stdexcept>
 
 namespace lantern
 {


### PR DESCRIPTION
Hello.

When I try to compile library and example I got few compiler errors: ```'matrix4x4f' was not declared in this scope``` and ```'runtime_error' is not a member of 'std'```. So let me introduce my view of fixing of that errors in this pull request.

Please note so there is also linking error:
```[ 95%] Linking CXX executable examples\empty_app\empty_app.exe
\cmake-3.3.0-win32-x86\bin\cmake.exe -E cmake_link_script CMakeFiles\empty_app.dir\link.txt --verbose=1
\cmake-3.3.0-win32-x86\bin\cmake.exe -E remove -f CMakeFiles\empty_app.dir/objects.a
\mingw32-i686-5.1.0-release-posix-sjlj-rt_v4-rev0\bin\ar.exe cr CMakeFiles\empty_app.dir/objects.a @CMakeFiles\empty_app.dir\objects1.rsp
\mingw32-i686-5.1.0-release-posix-sjlj-rt_v4-rev0\bin\g++.exe   -std=gnu++0x -Wall -Wno-comment  -mwindows -Wl,--whole-archive CMakeFiles\empty_app.dir/objects.a -Wl,--no-whole-archive  -o examples\empty_app\empty_app.exe -Wl,--out-implib,libempty_app.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles\empty_app.dir\linklibs.rsp
/SDL2-devel-2.0.3-mingw/lib/x86/SDL2main.lib(./Release/SDL_windows_main.obj):(.text[_main]+0x0): multiple definition of `main'
/mingw32-i686-5.1.0-release-posix-sjlj-rt_v4-rev0/bin/../lib/gcc/i686-w64-mingw32/5.1.0/../../../../i686-w64-mingw32/lib/../lib/libmingw32.a(lib32_libmingw32_a-crt0_c.o):crt0_c.c:(.text.startup+0x0): first defined here
Warning: corrupt .drectve at end of def file
collect2.exe: error: ld returned 1 exit status```
but not sure where is a place of problem: project, cmake or compile.
One of solution, if we say that is project problem, is something like this - at ```CMakeList.txt``` before first use of SDL2_LIBRARY place next code:
```if (NOT UNIX)
  if (NOT MSVC)
    list(REMOVE_ITEM SDL2_LIBRARY "mingw32")
  endif (NOT MSVC)
endif (NOT UNIX)```
If this cmake problem - find library should-not add ```mingw32``` to library list.
If this compile error - so need to try at new version.
