### PR TITLE
[tests] tests target do not need to link with 3rd party libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,39 +104,12 @@ set_target_properties(
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
 
 target_link_libraries(tests lantern gtest)
-target_link_libraries(tests lantern ${SDL2_LIBRARY} ${SDL2IMAGE_LIBRARY})
 
 add_custom_command(
     TARGET tests POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     "${PROJECT_SOURCE_DIR}/tests/resources"
     $<TARGET_FILE_DIR:tests>/resources)
-
-if (WIN32)
-    add_custom_command(
-        TARGET tests
-        POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
-        "${SDL2_DLL}"
-        $<TARGET_FILE_DIR:tests>)
-
-    add_custom_command(
-        TARGET tests
-        POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
-        "${SDL2IMAGE_DLL}"
-        $<TARGET_FILE_DIR:tests>)
-
-	add_custom_command(
-        TARGET tests
-        POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
-        "${SDL2IMAGE_LIBPNG_DLL}"
-        $<TARGET_FILE_DIR:tests>)
-
-	add_custom_command(
-        TARGET tests
-        POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
-        "${SDL2IMAGE_ZLIB_DLL}"
-        $<TARGET_FILE_DIR:tests>)
-endif()
 # ===========================================
 
 # Empty app target ==========================


### PR DESCRIPTION
Hello.

Actually at this point in tests source do not use any function from lantern libraries that required 3rd party libraries, so it can be removed from depends. And that why 3d party binaries also do not need to copy in post-build state.

Thanks.